### PR TITLE
Fix: 임베딩 방식 변경 / 제거된 클래스 삭제 및 리네이밍 / 프롬포트 파일 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,4 @@ st_app/tests/
 
 *.parquet
 build_*.py
+settings.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -96,3 +96,4 @@ langgraph==0.6.3
 
 tokenizers>=0.20,<0.21
 transformers<4.46
+openai>=1.86,<2.0

--- a/st_app/graph/nodes/rag_review_node.py
+++ b/st_app/graph/nodes/rag_review_node.py
@@ -1,21 +1,8 @@
 from langchain_core.prompts import ChatPromptTemplate
 from st_app.rag.llm import get_llm
-from st_app.utils.state import AppState, Doc
+from st_app.utils.state import AppState
 from st_app.rag.retriever import Retriever
-
-prompt = ChatPromptTemplate.from_messages([
-    ("system",
-     "다음 리뷰 스니펫만 근거로 답하라. 장단점을 요약하고, 모순/편향이 보이면 간단히 경고해. "
-     "각 스니펫은 (site|author|date|rating)로 인용해."),
-    ("system", "SNIPPETS:\n{snippets}"),
-    ("human", "질문: {q}")
-])
-
-def _fmt_snippets(docs: list[Doc]) -> str:
-    return "\n".join(
-        f"- {d['text']}  ({d['meta']['site']}|{d['meta']['author']}|{d['meta']['date']}|{d['meta']['rating']})"
-        for d in docs
-    )
+from st_app.rag.prompt import build_rag_messages
 
 def run(state: AppState) -> AppState:
     llm = get_llm(temperature=0.2)
@@ -27,7 +14,7 @@ def run(state: AppState) -> AppState:
         filters={"sites": prefs.get("sites"), "min_rating": prefs.get("min_rating")}
     )
     state["retrieved"] = docs
-    msgs = prompt.format_messages(snippets=_fmt_snippets(docs), q=state["query"])
+    msgs = build_rag_messages(state["query"], docs)
     out = llm.invoke(msgs)
     state["answer"] = out.content
     state["citations"] = [{**d["meta"], "snippet": d["text"]} for d in docs]

--- a/st_app/graph/nodes/rag_review_node.py
+++ b/st_app/graph/nodes/rag_review_node.py
@@ -1,11 +1,7 @@
 from langchain_core.prompts import ChatPromptTemplate
 from st_app.rag.llm import get_llm
 from st_app.utils.state import AppState, Doc
-try:
-    from st_app.rag.retriever import FaissRetriever as Retriever
-except Exception:
-    # 빌드 전에도 돌아가도록 안전 폴백
-    from st_app.rag.retriever import MockRetriever as Retriever
+from st_app.rag.retriever import Retriever
 
 prompt = ChatPromptTemplate.from_messages([
     ("system",

--- a/st_app/rag/embedder.py
+++ b/st_app/rag/embedder.py
@@ -1,0 +1,151 @@
+import argparse, json, os, time
+from pathlib import Path
+import numpy as np
+import pandas as pd
+import faiss
+from dotenv import load_dotenv
+from openai import OpenAI, BadRequestError
+
+load_dotenv()
+
+OUT_DIR_DEFAULT = "st_app/db/faiss_index"
+
+# Upstage OpenAI-호환 엔드포인트
+BASE_URL = os.getenv("UPSTAGE_BASE_URL", "https://api.upstage.ai/v1")
+API_KEY  = os.getenv("UPSTAGE_API_KEY")
+MODEL_DOC = os.getenv("UPSTAGE_EMBED_MODEL_DOC", "solar-embedding-1-large-passage")
+BATCH = int(os.getenv("EMBED_BATCH", "64"))
+MAX_CHARS = int(os.getenv("EMBED_MAX_CHARS", "5000"))
+
+client = OpenAI(api_key=API_KEY, base_url=BASE_URL)
+
+def _require_key():
+    if not API_KEY:
+        raise RuntimeError("UPSTAGE_API_KEY not set")
+
+def _l2_norm(a: np.ndarray) -> np.ndarray:
+    n = np.linalg.norm(a, axis=1, keepdims=True) + 1e-12
+    return (a / n).astype(np.float32)
+
+def _sanitize_texts(texts: list[str]) -> list[str]:
+    clean = []
+    for t in texts:
+        s = ("" if t is None else str(t)).strip()
+        if not s:
+            continue
+        if len(s) > MAX_CHARS:
+            s = s[:MAX_CHARS]  # 너무 긴 입력은 자름
+        clean.append(s)
+    return clean
+
+def _embed_batch(batch: list[str], model: str, retry=0) -> np.ndarray:
+    # 문제가 되는 배치를 자동으로 쪼개 재시도
+    try:
+        resp = client.embeddings.create(model=model, input=batch)
+        vecs = [d.embedding for d in resp.data]
+        return np.asarray(vecs, dtype=np.float32)
+    except BadRequestError as e:
+        # '$.input' invalid 같은 400 에러 → 절반으로 쪼개 재귀
+        if len(batch) > 1:
+            mid = len(batch) // 2
+            left = _embed_batch(batch[:mid], model, retry)
+            right = _embed_batch(batch[mid:], model, retry)
+            return np.vstack([left, right])
+        raise
+    except Exception:
+        # 일시적 오류는 간단 백오프 후 1회 재시도
+        if retry < 2:
+            time.sleep(1.5 * (retry + 1))
+            return _embed_batch(batch, model, retry+1)
+        raise
+    
+def _embed_texts(texts: list[str], model: str, batch_size: int = BATCH) -> np.ndarray:
+    _require_key()
+    texts = _sanitize_texts(texts)
+    if not texts:
+        raise RuntimeError("임베딩할 유효 텍스트가 없습니다.")
+    chunks = []
+    for i in range(0, len(texts), batch_size):
+        batch = texts[i:i+batch_size]
+        vecs = _embed_batch(batch, model)
+        chunks.append(vecs)
+    embs = np.vstack(chunks)
+    return np.ascontiguousarray(_l2_norm(embs), dtype=np.float32)
+
+def chunk_text(t: str, size: int = 800, overlap: int = 100) -> list[str]:
+    t = (t or "").strip()
+    if not t: return []
+    if overlap < 0 or size <= 0 or overlap >= size:
+        raise ValueError(f"Invalid chunk params: size={size}, overlap={overlap}")
+    if len(t) <= size: return [t]
+    step = size - overlap
+    return [t[i:i+size] for i in range(0, len(t), step)]
+
+def build(args):
+    in_path = Path(args.input)
+    out_dir = Path(args.out or OUT_DIR_DEFAULT)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    df = pd.read_parquet(in_path)
+    req = {"review_id","source","author","rating_norm","review_text","created_at","url"}
+    missing = req - set(df.columns)
+    if missing:
+        raise ValueError(f"필수 컬럼 누락: {missing}")
+
+    # 레코드 → 청크
+    records, texts = [], []
+    for _, r in df.iterrows():
+        for j, c in enumerate(chunk_text(str(r["review_text"]), size=args.chunk_size, overlap=args.overlap)):
+            records.append({
+                "review_id": r["review_id"],
+                "chunk_id": f"{r['review_id']}#{j}",
+                "source": r["source"],
+                "author": r["author"],
+                "rating": float(r["rating_norm"]),
+                "date": str(r["created_at"]),
+                "url": r["url"],
+                "text": c
+            })
+            texts.append(c)
+
+    if not records:
+        raise RuntimeError("청크가 생성되지 않았습니다. 입력을 확인하세요.")
+
+    # 임베딩(API) → FAISS
+    embs = _embed_texts(texts, model=MODEL_DOC, batch_size=args.batch)
+    if embs.shape[0] != len(records):
+        raise RuntimeError("임베딩 수와 레코드 수가 일치하지 않습니다.")
+    d = embs.shape[1]
+    index = faiss.IndexFlatIP(d)   # 코사인 = 내적 (정규화 완료)
+    index.add(embs)
+    faiss.write_index(index, str(out_dir / "index.faiss"))
+
+    # 메타/세팅 저장
+    with open(out_dir / "meta.jsonl", "w", encoding="utf-8") as f:
+        for rec in records:
+            f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+    with open(out_dir / "settings.json", "w", encoding="utf-8") as f:
+        json.dump({
+            "embed_model_doc": MODEL_DOC,
+            "normalized": True,
+            "index_type": "IndexFlatIP",
+            "chunk_size": args.chunk_size,
+            "overlap": args.overlap,
+            "n_chunks": len(records),
+            "base_url": BASE_URL
+        }, f, ensure_ascii=False, indent=2)
+
+    print(f"[OK] index:{len(records)} chunks  dim:{d}")
+    print(f" - {out_dir/'index.faiss'}")
+    print(f" - {out_dir/'meta.jsonl'}")
+    print(f" - {out_dir/'settings.json'}")
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--input", required=True, help="reviews_ready.parquet")
+    p.add_argument("--out", default=OUT_DIR_DEFAULT)
+    p.add_argument("--chunk_size", type=int, default=800)
+    p.add_argument("--overlap", type=int, default=100)
+    p.add_argument("--batch", type=int, default=BATCH)
+    args = p.parse_args()
+    build(args)

--- a/st_app/rag/prompt.py
+++ b/st_app/rag/prompt.py
@@ -1,0 +1,23 @@
+from typing import List, Dict
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+
+SYSTEM_RAG = (
+    "주어진 리뷰 스니펫만 근거로 답해. 장단점을 요약하고, 모순/편향이 보이면 경고해. "
+    "각 스니펫을 (site|author|date|rating)로 인용해. 추측 금지."
+)
+
+def format_snippets(docs: List[Dict]) -> str:
+    # docs[i] = {"text": "...", "meta": {...}}
+    lines = []
+    for d in docs:
+        m = d["meta"]
+        lines.append(f"- {d['text']}  ({m['site']}|{m['author']}|{m['date']}|{m['rating']})")
+    return "\n".join(lines)
+
+def build_rag_messages(query: str, docs: List[Dict]):
+    tmpl = ChatPromptTemplate.from_messages([
+        ("system", SYSTEM_RAG),
+        ("system", "SNIPPETS:\n{snippets}"),
+        ("human", "질문: {q}")
+    ])
+    return tmpl.format_messages(snippets=format_snippets(docs), q=query)

--- a/st_app/rag/retriever.py
+++ b/st_app/rag/retriever.py
@@ -6,7 +6,7 @@ import numpy as np
 import faiss
 from dotenv import load_dotenv
 from openai import OpenAI
-from st_app.graph.state import Doc
+from st_app.utils.state import Doc
 
 load_dotenv()
 
@@ -28,7 +28,7 @@ def _embed_query(q: str) -> np.ndarray:
     v /= (np.linalg.norm(v, axis=1, keepdims=True) + 1e-12)  # L2 정규화
     return np.ascontiguousarray(v, dtype=np.float32)
 
-class FaissRetriever:
+class Retriever:
     def __init__(self, index_dir: str = "st_app/db/faiss_index", overfetch: int = OVERFETCH):
         self.index_dir = Path(index_dir)
         self.index = faiss.read_index(str(self.index_dir / "index.faiss"))

--- a/st_app/rag/retriever.py
+++ b/st_app/rag/retriever.py
@@ -1,51 +1,67 @@
 from __future__ import annotations
-import json
+import json, os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 import numpy as np
 import faiss
-from sentence_transformers import SentenceTransformer
-from st_app.utils.state import Doc
+from dotenv import load_dotenv
+from openai import OpenAI
+from st_app.graph.state import Doc
 
-class Retriever:
-    def __init__(self,
-                 index_dir: str = "st_app/db/faiss_index",
-                 model_name: str = "sentence-transformers/paraphrase-multilingual-mpnet-base-v2",
-                 overfetch: int = 5):
+load_dotenv()
+
+BASE_URL = os.getenv("UPSTAGE_BASE_URL", "https://api.upstage.ai/v1")
+API_KEY  = os.getenv("UPSTAGE_API_KEY")
+MODEL_QUERY = os.getenv("UPSTAGE_EMBED_MODEL_QUERY", "solar-embedding-1-large-query")
+OVERFETCH = int(os.getenv("RETRIEVER_OVERFETCH", "5"))
+
+client = OpenAI(api_key=API_KEY, base_url=BASE_URL)
+
+def _require_key():
+    if not API_KEY:
+        raise RuntimeError("UPSTAGE_API_KEY 환경변수가 설정되어 있지 않습니다.")
+
+def _embed_query(q: str) -> np.ndarray:
+    _require_key()
+    resp = client.embeddings.create(model=MODEL_QUERY, input=q)
+    v = np.asarray(resp.data[0].embedding, dtype=np.float32)[None, :]
+    v /= (np.linalg.norm(v, axis=1, keepdims=True) + 1e-12)  # L2 정규화
+    return np.ascontiguousarray(v, dtype=np.float32)
+
+class FaissRetriever:
+    def __init__(self, index_dir: str = "st_app/db/faiss_index", overfetch: int = OVERFETCH):
         self.index_dir = Path(index_dir)
         self.index = faiss.read_index(str(self.index_dir / "index.faiss"))
-        self.model = SentenceTransformer(model_name)
-        # meta.jsonl 로드
+        # 메타
         self.meta: List[Dict[str, Any]] = []
         with open(self.index_dir / "meta.jsonl", "r", encoding="utf-8") as f:
             for line in f:
                 self.meta.append(json.loads(line))
         self.overfetch = max(1, int(overfetch))
 
-    def _embed(self, q: str) -> np.ndarray:
-        v = self.model.encode([q], normalize_embeddings=True, convert_to_numpy=True)
-        return v.astype(np.float32)
-
     def retrieve(self, query: str, k: int = 6, filters: Optional[Dict[str, Any]] = None) -> List[Doc]:
         filters = filters or {}
         sites = set(filters.get("sites") or []) or None
         min_rating = float(filters.get("min_rating") or 0.0)
 
-        q = self._embed(query)
-        # 초과 조회 후 필터링
-        over_k = max(k * self.overfetch, k)
-        scores, idxs = self.index.search(q, over_k)  # (1, over_k)
-        result: List[Doc] = []
+        qv = _embed_query(query)
+        topn = max(k * self.overfetch, k)
+        scores, idxs = self.index.search(qv, topn)
+        out: List[Doc] = []
         for i in idxs[0].tolist():
             if i < 0: continue
             m = self.meta[i]
-            if sites and m["source"] not in sites:
+            if sites and m["source"] not in sites:  # 필터
                 continue
             if m["rating"] < min_rating:
                 continue
-            result.append({"text": m["text"], "meta": {
-                "site": m["source"], "author": m["author"], "date": m["date"],
-                "rating": m["rating"], "url": m["url"], "review_id": m["review_id"], "chunk_id": m["chunk_id"]
-            }})
-            if len(result) >= k: break
-        return result
+            out.append({
+                "text": m["text"],
+                "meta": {
+                    "site": m["source"], "author": m["author"], "date": m["date"],
+                    "rating": m["rating"], "url": m["url"],
+                    "review_id": m["review_id"], "chunk_id": m["chunk_id"]
+                }
+            })
+            if len(out) >= k: break
+        return out

--- a/st_app/rag/retriever.py
+++ b/st_app/rag/retriever.py
@@ -7,7 +7,7 @@ import faiss
 from sentence_transformers import SentenceTransformer
 from st_app.utils.state import Doc
 
-class MockRetriever:
+class Retriever:
     def __init__(self,
                  index_dir: str = "st_app/db/faiss_index",
                  model_name: str = "sentence-transformers/paraphrase-multilingual-mpnet-base-v2",


### PR DESCRIPTION
### 작업 내용

- 로컬 sentence-transformers 의존을 제거하고 Upstage 임베딩 API로 전환
- 사용되지 않는 클래스/모듈 정리 및 리네이밍으로 구조 단순화
- RAG 전용 프롬프트를 `st_app/rag/prompt.py`로 분리

### 변경 사항

- `st_app/graph/nodes/rag_review_node.py`, `st_app/rag/prompt.py` : 프롬포트 분리
- `st_app/rag/embedder.py`, `st_app/rag/retriever.py` : 로컬 임베딩->Upstage API 임베딩

### 호환성

- 랭그래프 혹은 스트림릿 작업과 충돌하는 부분은 없으니 기존 작업하시던 대로 진행하시면 됩니다.
- `UPSTAGE_API_KEY`를 제외한 환경변수는 선택사항입니다. (지정하지 않아도 디폴트로 작동)

### 테스트

chatbottest 브랜치에서 작동 테스트 가능합니다.
<img width="2720" height="1046" alt="스크린샷 2025-08-11 140152" src="https://github.com/user-attachments/assets/e2a233ed-eac3-499b-9231-2815efcb172b" />
